### PR TITLE
Remove drush cr call from update-config workflow

### DIFF
--- a/.github/workflows/update-config.yml
+++ b/.github/workflows/update-config.yml
@@ -47,8 +47,6 @@ jobs:
           # Make sure new patches are installed.
           composer install --no-interaction --no-dev
 
-          drush cr
-
           # Update translations from localize.drupal.org and helfi-modules
           # before running update hooks to reduce clutter in configuration files.
           drush locale:check && drush locale:update


### PR DESCRIPTION
Drush cr causes a container rebuild, which errors out if modules defines new dependencies that are not yet installed, but would be installed in an update hook.

I don't see why drush cr would be required here.