### PR TITLE
Add `check_config_language_ignore_files` to allow skipping certain conf files from `check_config_language`

### DIFF
--- a/.github/workflows/project-tests.yml
+++ b/.github/workflows/project-tests.yml
@@ -16,11 +16,10 @@ on:
         default: true
         required: false
         type: boolean
-      check_config_language_ignore_webform:
-        description: 'Check configurations are exported in correct language, but ignore webforms'
-        default: true
+      check_config_language_ignore_files:
+        description: 'Array of file patterns to ignore during langcode check'
         required: false
-        type: boolean
+        type: array
     secrets:
       sonarcloud_token:
         required: false
@@ -45,8 +44,10 @@ jobs:
         if: ${{ inputs.check_config_language }}
         run: |
           IGNORE_PATTERN=""
-          if [ "${{ inputs.check_config_language_ignore_webform }}" == "true" ]; then
-            IGNORE_PATTERN="--exclude='webform.webform.*'"
+          if [ -n "${{ inputs.check_config_language_ignore_files }}" ]; then
+            # Parse array patterns and build exclude patterns
+            IGNORE_FILES='${{ inputs.check_config_language_ignore_files }}'
+            IGNORE_PATTERN=$(echo "$IGNORE_FILES" | tr ' ' '\n' | sed "s/^/--exclude='/; s/$/'/" | tr '\n' ' ')
           fi
 
           OUTPUT=$(grep -oP '^langcode: \b(?!(?:en|und)\b)\w+' conf -R $IGNORE_PATTERN || true)

--- a/.github/workflows/project-tests.yml
+++ b/.github/workflows/project-tests.yml
@@ -16,6 +16,11 @@ on:
         default: true
         required: false
         type: boolean
+      check_config_language_ignore_webform:
+        description: 'Check configurations are exported in correct language, but ignore webforms'
+        default: true
+        required: false
+        type: boolean
     secrets:
       sonarcloud_token:
         required: false
@@ -39,7 +44,12 @@ jobs:
       - name: Make sure configuration was exported in correct language (en or und)
         if: ${{ inputs.check_config_language }}
         run: |
-          OUTPUT=$(grep -oP '^langcode: \b(?!(?:en|und)\b)\w+' conf -R || true)
+          IGNORE_PATTERN=""
+          if [ "${{ inputs.check_config_language_ignore_webform }}" == "true" ]; then
+            IGNORE_PATTERN="--exclude='webform.webform.*'"
+          fi
+
+          OUTPUT=$(grep -oP '^langcode: \b(?!(?:en|und)\b)\w+' conf -R $IGNORE_PATTERN || true)
           if [ ! -z "$OUTPUT" ]; then
             echo "Found configuration that does not match the pattern 'langcode: (en|und)':" >> $GITHUB_STEP_SUMMARY
             echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Some projects may have e.g. webforms only with Finnish language, this is bit problematic for the language config language check.

PR adds possibility to pass an array of files (also wildcards can be used) to define the config files that should not be tested.

For example 
```
with:
  check_config_language: true
  check_config_language_ignore_files: 
    - "webform.webform*"
```